### PR TITLE
Add google map

### DIFF
--- a/urban-trails/src/App.js
+++ b/urban-trails/src/App.js
@@ -1,13 +1,25 @@
-import './App.css';
+// import './App.css';
+import { Component } from "react";
+import {Map, GoogleApiWrapper} from "google-maps-react";
 
-function App() {
-  return (
-    <div className="App">
-      <header className="App-header">
-        <h1>Urban Trails</h1>
-      </header>
-    </div>
-  );
+class MapContainer extends Component {
+  render() {
+    return(
+      <Map
+        google = {this.props.google}
+        style = {{width: "100%", height: "100%"}}
+        zoom = {10}
+        initialCenter = {
+          {
+          lat: 47.6062,
+          lng: -122.3321
+          }
+        }
+      />
+    );
+  }
 }
 
-export default App;
+export default GoogleApiWrapper({
+  apiKey: ""
+})(MapContainer)


### PR DESCRIPTION
Closes #6   - Add Google Map/API

### Please Note: A Google Map API Key is needed to take off the watermark. Available upon request. 

## Description of Change

Creates a Google Map API Key and adds a map to the home screen

## How to test
- Clone the repo https://github.com/davidnguyen234/urban-trails
- Cd into urban-trails folder
- Checkout add-map branch
- Cd into urban-trails folder 
- Run npm install
- Run npm start
- The app should automatically start in your web browser with URL http://localhost:3000/ and a map on the home screen

![Screen Shot 2022-05-27 at 3 16 16 PM](https://user-images.githubusercontent.com/47171828/170795982-ab0141e6-7106-4711-89d2-399e0d0129f5.png)

