### PR TITLE
add map markers and infowindows

### DIFF
--- a/urban-trails/src/components/Map.jsx
+++ b/urban-trails/src/components/Map.jsx
@@ -1,33 +1,93 @@
-import React, {Component} from 'react';
-import {Map, GoogleApiWrapper} from "google-maps-react";
+import React, {Component } from 'react';
+import {Map, GoogleApiWrapper, Marker, InfoWindow} from "google-maps-react";
 import Navigation from './Navigation';
 import '../App.css';
 
-class MapContainer extends Component {
-  render() {
-    return(
-      <div>
-        <div>
-        <Navigation />
-        </div>
-        <div className="content">
-            <Map
-              google = {this.props.google}
-              style = {{width: "100%", height: "100%"}}
-              zoom = {10}
-              initialCenter = {
-                {
-                lat: 47.6062,
-                lng: -122.3321
-                }
-              }
-            />
-        </div>
-      </div>
-    );
+export class MapContainer extends Component {
+    state = {
+      showInfoWindow: false,
+      activeTrail: {},
+      selectedTrail: {},
+      trailLocations: []
+    };
+  
+    componentDidMount() {
+      fetch("https://firestore.googleapis.com/v1beta1/projects/urban-trails-3a784/databases/(default)/documents/trails")
+      .then(response => response.json())
+      .then(data => this.setState({ trailLocations: data}))
+  };
+  
+  renderTrails() {
+    console.log(this.state.trailLocations)
+    return this.state.trailLocations.map((trails, i) => { 
+      return <Marker
+            key={i}
+            onClick={this.trailClick}
+            id={trails.id}
+            position={{
+              lat: trails.latitude,
+              lng: trails.longitude
+            }}
+            title={trails.title}
+            description={trails.description}
+          />
+      })
+  };
+  
+  trailClick = (props, marker) =>
+  this.setState({
+    selectedTrail: props,
+    activeTrail: marker,
+    showInfoWindow: true
+  });
+  
+  mapClick = () => {
+  if (this.state.showInfoWindow) {
+    this.setState({
+      showInfoWindow: false,
+      activeTrail: null
+    })
   }
-}
+  };
+  
+  render() {
+  return (
+    <div>
+      <div>
+      <Navigation />
+      </div>
+      <div>
+      <Map google={this.props.google}
+        center={{
+          lat: 47.606209,
+          lng: -122.332069
+        }}
+        zoom={11}
+        onClick={this.mapClick}
+      >
+    
+        {this.renderTrails()}
 
-export default GoogleApiWrapper({
-  apiKey: process.env.REACT_APP_GOOGLE_API_KEY
-})(MapContainer)
+        <InfoWindow
+          marker={this.state.activeTrail}
+          visible={this.state.showInfoWindow}
+          onClose={this.onInfoWindowClose}
+        >
+          <div id="info">
+            <h3> Trail {this.state.selectedTrail.id}</h3> <br></br>
+            <p>{this.state.selectedTrail.title}</p>
+            <p>{this.state.selectedTrail.description}</p>
+    <br></br>
+          </div>
+        </InfoWindow>
+      </Map>
+      </div>
+    </div>
+  );
+  }
+  }
+  
+  export default GoogleApiWrapper({
+    apiKey: process.env.REACT_APP_GOOGLE_API_KEY
+  })(MapContainer)
+  

--- a/urban-trails/src/components/Map.jsx
+++ b/urban-trails/src/components/Map.jsx
@@ -12,24 +12,33 @@ export class MapContainer extends Component {
     };
   
     componentDidMount() {
-      fetch("https://firestore.googleapis.com/v1beta1/projects/urban-trails-3a784/databases/(default)/documents/trails")
+      fetch(`${process.env.REACT_APP_FIRESTORE_URL}`)
       .then(response => response.json())
-      .then(data => this.setState({ trailLocations: data}))
+      .then(data => this.setState({ trailLocations: data.documents}))
   };
   
   renderTrails() {
-    console.log(this.state.trailLocations)
-    return this.state.trailLocations.map((trails, i) => { 
+    return this.state.trailLocations.map((trails, i) => {
+      const trailLocation = {
+        id: trails.name, 
+        latitude: trails.fields.location.geoPointValue.latitude,
+        longitude: trails.fields.location.geoPointValue.longitude, 
+        title: trails.fields.title.stringValue,
+        description: trails.fields.description.stringValue,
+        image: trails.fields.image.stringValue
+      }
       return <Marker
             key={i}
             onClick={this.trailClick}
-            id={trails.id}
+            id={trailLocation.id}
             position={{
-              lat: trails.latitude,
-              lng: trails.longitude
+              lat: trailLocation.latitude,
+              lng: trailLocation.longitude
             }}
-            title={trails.title}
-            description={trails.description}
+            title={trailLocation.title}
+            description={trailLocation.description}
+            latitude={trailLocation.latitude}
+            longitude={trailLocation.longitude}
           />
       })
   };
@@ -74,17 +83,15 @@ export class MapContainer extends Component {
           onClose={this.onInfoWindowClose}
         >
           <div id="info">
-            <h3> Trail {this.state.selectedTrail.id}</h3> <br></br>
             <p>{this.state.selectedTrail.title}</p>
             <p>{this.state.selectedTrail.description}</p>
-    <br></br>
+            <p>{this.state.selectedTrail.latitude}° N, {this.state.selectedTrail.longitude}° W</p>
           </div>
         </InfoWindow>
       </Map>
       </div>
     </div>
-  );
-  }
+    )}
   }
   
   export default GoogleApiWrapper({

--- a/urban-trails/src/components/Trails.js
+++ b/urban-trails/src/components/Trails.js
@@ -1,22 +1,22 @@
 import React, { useState, useEffect } from 'react';
 import { db } from '../firebase-config';
-import { collection, getDocs, addDoc, deleteDoc, doc } from 'firebase/firestore';
+import { collection, getDocs, addDoc, deleteDoc, doc, GeoPoint } from 'firebase/firestore';
 import Navigation from './Navigation';
 import '../App.css';
 
 const Trails = () => {
-    const [newName, setNewName] = useState("")
+    const [newTitle, setNewTitle] = useState("")
     const [newDescription, setNewDescription] = useState("")
     const [newImage, setNewImage] = useState("")
     const [newLatitude, setNewLatitude] = useState(0)
     const [newLongitude, setNewLongitude] = useState(0)
-
-
     const [trails, setTrails] = useState([]);
     const trailsCollectionRef = collection(db, "trails")
     
     const createTrail = async () => {
-        await addDoc(trailsCollectionRef, {name: newName, description: newDescription, latitude: newLatitude, longitude: newLongitude , image: newImage})
+        await addDoc(trailsCollectionRef, {title: newTitle, description: newDescription,
+            location: new GeoPoint(newLatitude, newLongitude),
+            image: newImage})
     }
 
     const deleteTrail = async (id) => {
@@ -41,7 +41,7 @@ const Trails = () => {
         <div className="content">
             <h1>Trails</h1>
             <input placeholder="Name" onChange={(event) => {
-                setNewName(event.target.value);
+                setNewTitle(event.target.value);
             }}></input>
             <input placeholder="Description" onChange={(event) => {
                 setNewDescription(event.target.value);
@@ -62,9 +62,9 @@ const Trails = () => {
                     <div>
                         {" "}
                         <img src={trail.image} alt="trail"/>
-                        <h3>{trail.name}</h3>
+                        <h3>{trail.title}</h3>
+                        <p>{trail.location.latitude}° N, {trail.location.longitude}° W</p>
                         <p>{trail.description}</p>
-                        <p>Coordinates: {trail.latitude}, {trail.longitude}</p>
                         <button onClick={() => {deleteTrail(trail.id)}
                         }>Delete Trail</button><br/><br/><br/>
                     </div>    


### PR DESCRIPTION
Closes #18 Closes #26 Closes #27 

Adds markers to the map with firestore data. When a marker is selected, an infowindow pop up with info for that specific marker. Fixes the bug when creating a new geopoint. 

## How to test
- Clone the repo https://github.com/davidnguyen234/urban-trails
- Cd into urban-trails folder
- Run npm install
- Run npm start
- Checkout markers branch

<img width="394" alt="Screen Shot 2022-07-11 at 6 42 47 PM" src="https://user-images.githubusercontent.com/47171828/178390269-4fc87a61-c100-42ed-91b4-f3657c58e1ad.png">

<img width="839" alt="Screen Shot 2022-07-11 at 6 42 54 PM" src="https://user-images.githubusercontent.com/47171828/178390302-984a6b5f-bb91-4b32-86d4-4eae32337f7a.png">



